### PR TITLE
ViewGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ## Added:
 
  * `View` trait
+ * `ViewGroup` struct to allow working with multiple views
 
 ## Changed:
 

--- a/src/align/mod.rs
+++ b/src/align/mod.rs
@@ -23,7 +23,8 @@ where
     {
         let h = horizontal.align(self, reference);
         let v = vertical.align(self, reference);
-        self.translate(Point::new(h, v))
+        self.translate(Point::new(h, v));
+        self
     }
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,22 +1,17 @@
 use crate::prelude::*;
 use embedded_graphics::{geometry::Point, primitives::Rectangle};
 
-pub struct ChainTerminator;
-pub struct ViewLink<V: View, C: ViewChainElement> {
-    pub view: V,
-    pub next: C,
-}
-
-pub trait ViewChainElement {
+pub trait ViewChainElement: View {
     const HAS_BOUNDS: bool;
-
-    fn bounds(&self) -> Rectangle;
-    fn translate(&mut self, by: Point);
 }
+
+pub struct ChainTerminator;
 
 impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {
     const HAS_BOUNDS: bool = true;
+}
 
+impl<V: View, C: ViewChainElement> View for ViewLink<V, C> {
     fn bounds(&self) -> Rectangle {
         let bounds = self.view.bounds();
 
@@ -27,21 +22,30 @@ impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {
         }
     }
 
-    fn translate(&mut self, by: Point) {
+    fn translate(&mut self, by: Point) -> &mut Self {
         self.view.translate(by);
         self.next.translate(by);
+        self
     }
+}
+
+pub struct ViewLink<V: View, C: ViewChainElement> {
+    pub view: V,
+    pub next: C,
 }
 
 impl ViewChainElement for ChainTerminator {
     const HAS_BOUNDS: bool = false;
+}
 
+impl View for ChainTerminator {
     fn bounds(&self) -> Rectangle {
         Rectangle::new(Point::zero(), Point::zero())
     }
 
-    fn translate(&mut self, _by: Point) {
+    fn translate(&mut self, _by: Point) -> &mut Self {
         // nothing to do
+        self
     }
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,0 +1,52 @@
+use crate::prelude::*;
+
+pub struct ViewLink<V: View, C: ViewChainElement> {
+    pub view: V,
+    pub next: C,
+}
+
+pub struct ChainTerminator;
+pub trait ViewChainElement {}
+
+impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {}
+impl ViewChainElement for ChainTerminator {}
+
+pub struct ViewGroup<C: ViewChainElement> {
+    pub views: C,
+}
+
+impl ViewGroup<ChainTerminator> {
+    pub fn new() -> Self {
+        Self {
+            views: ChainTerminator,
+        }
+    }
+}
+
+impl<C: ViewChainElement> ViewGroup<C> {
+    fn add_view<V: View>(self, view: V) -> ViewGroup<ViewLink<V, C>> {
+        ViewGroup {
+            views: ViewLink {
+                view,
+                next: self.views,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::layout::*;
+    use embedded_graphics::{
+        geometry::{Point, Size},
+        primitives::{Circle, Rectangle},
+    };
+
+    #[test]
+    fn sanity_check() {
+        // Check if multiple different views can be included in the view group
+        let _ = ViewGroup::new()
+            .add_view(Rectangle::with_size(Point::zero(), Size::new(5, 10)))
+            .add_view(Circle::new(Point::zero(), 5));
+    }
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -88,6 +88,10 @@ impl View for ChainTerminator {
 
 /// Group multiple `View`s together
 ///
+/// `ViewGroup` takes ownership over the views, so make sure you set them up before creating
+/// the group.
+/// The bounds and size of a `ViewGroup` envelops all the contained `View`s.
+///
 /// Note: translating an empty `ViewGroup` has no effect
 pub struct ViewGroup<C: ViewChainElement> {
     views: C,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,18 +1,52 @@
 use crate::prelude::*;
+use embedded_graphics::{geometry::Point, primitives::Rectangle};
 
+pub struct ChainTerminator;
 pub struct ViewLink<V: View, C: ViewChainElement> {
     pub view: V,
     pub next: C,
 }
 
-pub struct ChainTerminator;
-pub trait ViewChainElement {}
+pub trait ViewChainElement {
+    const HAS_BOUNDS: bool;
 
-impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {}
-impl ViewChainElement for ChainTerminator {}
+    fn bounds(&self) -> Rectangle;
+    fn translate(&mut self, by: Point);
+}
+
+impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {
+    const HAS_BOUNDS: bool = true;
+
+    fn bounds(&self) -> Rectangle {
+        let bounds = self.view.bounds();
+
+        if C::HAS_BOUNDS {
+            bounds.enveloping(&self.next.bounds())
+        } else {
+            bounds
+        }
+    }
+
+    fn translate(&mut self, by: Point) {
+        self.view.translate(by);
+        self.next.translate(by);
+    }
+}
+
+impl ViewChainElement for ChainTerminator {
+    const HAS_BOUNDS: bool = false;
+
+    fn bounds(&self) -> Rectangle {
+        Rectangle::new(Point::zero(), Point::zero())
+    }
+
+    fn translate(&mut self, _by: Point) {
+        // nothing to do
+    }
+}
 
 pub struct ViewGroup<C: ViewChainElement> {
-    pub views: C,
+    views: C,
 }
 
 impl ViewGroup<ChainTerminator> {
@@ -34,6 +68,17 @@ impl<C: ViewChainElement> ViewGroup<C> {
     }
 }
 
+impl<C: ViewChainElement> View for ViewGroup<C> {
+    fn translate(&mut self, by: Point) -> &mut Self {
+        self.views.translate(by);
+        self
+    }
+
+    fn bounds(&self) -> Rectangle {
+        self.views.bounds()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::layout::*;
@@ -45,8 +90,35 @@ mod test {
     #[test]
     fn sanity_check() {
         // Check if multiple different views can be included in the view group
-        let _ = ViewGroup::new()
+        let vg = ViewGroup::new()
             .add_view(Rectangle::with_size(Point::zero(), Size::new(5, 10)))
             .add_view(Circle::new(Point::zero(), 5));
+
+        fn check_vg<C: ViewChainElement>(_vg: &ViewGroup<C>) {}
+
+        check_vg(&vg);
+    }
+
+    #[test]
+    fn test() {
+        // Check if multiple different views can be included in the view group
+        let mut vg = ViewGroup::new()
+            .add_view(Rectangle::with_size(Point::zero(), Size::new(5, 10)))
+            .add_view(Rectangle::with_size(Point::new(3, 5), Size::new(5, 10)))
+            .add_view(Rectangle::with_size(Point::new(-2, -5), Size::new(5, 10)));
+
+        assert_eq!(Size::new(10, 20), vg.size());
+        assert_eq!(
+            Rectangle::new(Point::new(-2, -5), Point::new(7, 14)),
+            vg.bounds()
+        );
+
+        vg.translate(Point::new(2, 3));
+
+        assert_eq!(Size::new(10, 20), vg.size());
+        assert_eq!(
+            Rectangle::new(Point::new(0, -2), Point::new(9, 17)),
+            vg.bounds()
+        );
     }
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -5,7 +5,13 @@ pub trait ViewChainElement: View {
     const HAS_BOUNDS: bool;
 }
 
-pub struct ChainTerminator;
+/// Chain element that can store a `View` in a `ViewGroup`
+///
+/// You probably shouldn't ever use this struct
+pub struct ViewLink<V: View, C: ViewChainElement> {
+    pub view: V,
+    pub next: C,
+}
 
 impl<V: View, C: ViewChainElement> ViewChainElement for ViewLink<V, C> {
     const HAS_BOUNDS: bool = true;
@@ -29,10 +35,10 @@ impl<V: View, C: ViewChainElement> View for ViewLink<V, C> {
     }
 }
 
-pub struct ViewLink<V: View, C: ViewChainElement> {
-    pub view: V,
-    pub next: C,
-}
+/// The last chain element that marks the end of a `ViewGroup`
+///
+/// You probably shouldn't ever use this struct
+pub struct ChainTerminator;
 
 impl ViewChainElement for ChainTerminator {
     const HAS_BOUNDS: bool = false;
@@ -49,11 +55,15 @@ impl View for ChainTerminator {
     }
 }
 
+/// Group multiple `View`s together
+///
+/// Note: translating an empty `ViewGroup` has no effect
 pub struct ViewGroup<C: ViewChainElement> {
     views: C,
 }
 
 impl ViewGroup<ChainTerminator> {
+    /// Create a new, empty `ViewGroup` object
     pub fn new() -> Self {
         Self {
             views: ChainTerminator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 use embedded_graphics::{geometry::Point, prelude::*, primitives::Rectangle};
 
 mod align;
+mod layout;
 mod utils;
 
 use utils::rect_helper::RectExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub trait View {
         RectExt::size(&self.bounds())
     }
 
-    fn translate(&mut self, by: Point) -> &mut Self;
+    fn translate(&mut self, by: Point);
     fn bounds(&self) -> Rectangle;
 }
 
@@ -75,8 +75,8 @@ impl<T> View for T
 where
     T: Transform + Dimensions,
 {
-    fn translate(&mut self, by: Point) -> &mut Self {
-        self.translate_mut(by)
+    fn translate(&mut self, by: Point) {
+        self.translate_mut(by);
     }
 
     fn bounds(&self) -> Rectangle {

--- a/src/utils/rect_helper.rs
+++ b/src/utils/rect_helper.rs
@@ -30,6 +30,7 @@ pub trait RectExt {
     /// *Note:* when an object's width or height is an even number, the returned center point will
     ///         not be perfectly in the middle.
     fn center(&self) -> Point;
+    fn enveloping(&self, other: &Rectangle) -> Rectangle;
 }
 
 impl RectExt for Rectangle {
@@ -64,6 +65,39 @@ impl RectExt for Rectangle {
 
     fn center(&self) -> Point {
         Point::new(self.center_x(), self.center_y())
+    }
+
+    fn enveloping(&self, other: &Rectangle) -> Rectangle {
+        Rectangle::new(
+            Point::new(
+                self.top_left.x.min(other.top_left.x),
+                self.top_left.y.min(other.top_left.y),
+            ),
+            Point::new(
+                self.bottom_right.x.max(other.bottom_right.x),
+                self.bottom_right.y.max(other.bottom_right.y),
+            ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+    use embedded_graphics::{prelude::*, primitives::Rectangle};
+
+    #[test]
+    fn test_enveloping() {
+        let rect0 = Rectangle::new(Point::new(-1, -1), Point::new(0, 0));
+        let rect1 = Rectangle::new(Point::zero(), Point::new(1, 1));
+        let rect2 = Rectangle::new(Point::zero(), Point::new(2, 2));
+
+        assert_eq!(rect2, rect2.enveloping(&rect1));
+        assert_eq!(rect2, rect1.enveloping(&rect2));
+        assert_eq!(
+            Rectangle::new(Point::new(-1, -1), Point::new(2, 2),),
+            rect0.enveloping(&rect2)
+        );
     }
 }
 

--- a/src/utils/rect_helper.rs
+++ b/src/utils/rect_helper.rs
@@ -5,7 +5,6 @@ use embedded_graphics::{prelude::*, primitives::Rectangle};
 
 /// The trait that describes the extension methods.
 pub trait RectExt {
-
     /// Create a new `Rectangle` from a top left point and a `Size`
     fn with_size(top_left: Point, size: Size) -> Rectangle;
 
@@ -37,10 +36,7 @@ impl RectExt for Rectangle {
     fn with_size(top_left: Point, size: Size) -> Rectangle {
         Rectangle::new(
             top_left,
-            top_left + Point::new(
-                (size.width - 1) as i32,
-                (size.height - 1) as i32,
-            ),
+            top_left + Point::new((size.width - 1) as i32, (size.height - 1) as i32),
         )
     }
 
@@ -90,10 +86,7 @@ mod test {
     fn test_sized() {
         let rect0 = Rectangle::with_size(Point::new(-1, -1), Size::new(3, 3));
 
-        assert_eq!(
-            Point::new(1, 1),
-            rect0.bottom_right
-        );
+        assert_eq!(Point::new(1, 1), rect0.bottom_right);
     }
 
     #[test]

--- a/src/utils/rect_helper.rs
+++ b/src/utils/rect_helper.rs
@@ -87,6 +87,16 @@ mod test {
     use embedded_graphics::{prelude::*, primitives::Rectangle};
 
     #[test]
+    fn test_sized() {
+        let rect0 = Rectangle::with_size(Point::new(-1, -1), Size::new(3, 3));
+
+        assert_eq!(
+            Point::new(1, 1),
+            rect0.bottom_right
+        );
+    }
+
+    #[test]
     fn test_enveloping() {
         let rect0 = Rectangle::new(Point::new(-1, -1), Point::new(0, 0));
         let rect1 = Rectangle::new(Point::zero(), Point::new(1, 1));
@@ -97,22 +107,6 @@ mod test {
         assert_eq!(
             Rectangle::new(Point::new(-1, -1), Point::new(2, 2),),
             rect0.enveloping(&rect2)
-        );
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::prelude::*;
-    use embedded_graphics::{prelude::*, primitives::Rectangle};
-
-    #[test]
-    fn test_sized() {
-        let rect0 = Rectangle::with_size(Point::new(-1, -1), Size::new(3, 3));
-
-        assert_eq!(
-            Point::new(1, 1),
-            rect0.bottom_right
         );
     }
 }


### PR DESCRIPTION
ViewGroups link together multiple View objects. ViewGroups behave like other Views, they have a bounding rectangle and a size, that encompasses the included views. If all the included views are drawable, a ViewGroup is also drawable.

The API is still possibly not final and the docs/tests could use some improvement.

ViewGroups will serve as the basis of other implemented layout types.