### PR TITLE
Experimental: Wrapper to cache the bounding box of a view

### DIFF
--- a/src/layout/linear/mod.rs
+++ b/src/layout/linear/mod.rs
@@ -91,6 +91,7 @@ pub use orientation::{Horizontal, Orientation, Vertical};
 pub use secondary_alignment::SecondaryAlignment;
 pub use spacing::{ElementSpacing, FixedMargin};
 
+use crate::utils::cached::Cached;
 use layout_element::LayoutElement;
 use spacing::Tight;
 
@@ -221,10 +222,10 @@ where
     /// Views will be laid out sequentially, keeping the order in which they were added to the
     /// layout.
     #[inline]
-    pub fn add_view<V: View>(self, view: V) -> LinearLayout<LD, Link<V, LE>> {
+    pub fn add_view<V: View>(self, view: V) -> LinearLayout<LD, Link<Cached<V>, LE>> {
         LinearLayout {
             direction: self.direction,
-            views: self.views.add_view(view),
+            views: self.views.add_view(Cached::new(view)),
         }
     }
 

--- a/src/utils/cached.rs
+++ b/src/utils/cached.rs
@@ -1,0 +1,50 @@
+//! Bounding box cache wrapper
+use crate::prelude::*;
+use embedded_graphics::{primitives::Rectangle, DrawTarget};
+
+/// Cache the bounding box of the wrapped [`View`]
+pub struct Cached<V: View> {
+    bounds: Rectangle,
+    view: V,
+}
+
+impl<V: View> Cached<V> {
+    /// Calculate a View's bounding box and store it for reuse
+    #[inline]
+    pub fn new(v: V) -> Self {
+        let bounds = v.bounds();
+
+        Self { view: v, bounds }
+    }
+
+    /// Unwrap the inner View
+    #[inline]
+    pub fn into_inner(self) -> V {
+        self.view
+    }
+}
+
+impl<V: View> View for Cached<V> {
+    #[inline]
+    fn translate(&mut self, by: Point) {
+        self.bounds.translate(by);
+        self.view.translate(by);
+    }
+
+    #[inline]
+    fn bounds(&self) -> Rectangle {
+        self.bounds
+    }
+}
+
+impl<'a, V, C> Drawable<C> for &'a Cached<V>
+where
+    C: PixelColor,
+    V: View,
+    &'a V: Drawable<C>,
+{
+    #[inline]
+    fn draw<D: DrawTarget<C>>(self, display: &mut D) -> Result<(), D::Error> {
+        self.view.draw(display)
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Utility collection module
 
+pub mod cached;
 pub mod display_area;
 pub mod object_chain;
 pub mod rect_helper;


### PR DESCRIPTION
Automatically use the cache wrapper in LinearLayout, since it measures views multiple times during arrange.