### PR TITLE
Added Enum to ViewGroup derive macro

### DIFF
--- a/examples/dynamic_layout.rs
+++ b/examples/dynamic_layout.rs
@@ -1,0 +1,86 @@
+use embedded_graphics::{
+    pixelcolor::BinaryColor,
+    prelude::{PixelColor, Point, Size},
+    primitives::{Circle, Primitive, PrimitiveStyle, Rectangle, Styled, Triangle},
+    Drawable,
+};
+use embedded_graphics_simulator::{
+    BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, Window,
+};
+use embedded_layout::view_group::Views;
+use embedded_layout_macros::ViewGroup;
+
+#[derive(ViewGroup)]
+enum LayoutViews<C: PixelColor> {
+    TriangleView(Styled<Triangle, PrimitiveStyle<C>>),
+    CircleView(Styled<Circle, PrimitiveStyle<C>>),
+    RectangleView(Styled<Rectangle, PrimitiveStyle<C>>),
+    CombinedView(
+        Styled<Circle, PrimitiveStyle<C>>,
+        Styled<Rectangle, PrimitiveStyle<C>>,
+    ),
+    CombinedViewStruct {
+        circle: Styled<Circle, PrimitiveStyle<C>>,
+        square: Styled<Rectangle, PrimitiveStyle<C>>,
+    },
+}
+
+fn main() -> Result<(), core::convert::Infallible> {
+    let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(100, 50));
+    let output_settings = OutputSettingsBuilder::new()
+        .theme(BinaryColorTheme::OledBlue)
+        .build();
+
+    let mut views = Vec::new();
+
+    (0..5).for_each(|col_idx| {
+        (0..2).for_each(|row_idx| {
+            let view = match (col_idx + (row_idx * 5)) % 5 {
+                0 => {
+                    let p1 = Point::new(col_idx * 20, row_idx * 30);
+                    let p2 = Point::new((col_idx + 1) * 20, row_idx * 30);
+                    let p3 = Point::new((col_idx * 20) + 10, 20 + (row_idx * 30));
+
+                    LayoutViews::TriangleView(
+                        Triangle::new(p1, p2, p3)
+                            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1)),
+                    )
+                }
+                1 => LayoutViews::CircleView(
+                    Circle::new(Point::new(col_idx * 20, row_idx * 30), 20)
+                        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1)),
+                ),
+                2 => LayoutViews::RectangleView(
+                    Rectangle::new(Point::new(col_idx * 20, row_idx * 30), Size::new(20, 20))
+                        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1)),
+                ),
+                3 => {
+                    let circle = Circle::new(Point::new(col_idx * 20, row_idx * 30), 20)
+                        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+                    let square =
+                        Rectangle::new(Point::new(col_idx * 20, row_idx * 30), Size::new(20, 20))
+                            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+
+                    LayoutViews::CombinedView(circle, square)
+                }
+                4 => {
+                    let circle = Circle::new(Point::new(col_idx * 20, row_idx * 30), 20)
+                        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+                    let square =
+                        Rectangle::new(Point::new(col_idx * 20, row_idx * 30), Size::new(20, 20))
+                            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1));
+
+                    LayoutViews::CombinedViewStruct { circle, square }
+                }
+                _ => panic!("Out of bounds number"),
+            };
+
+            views.push(view);
+        });
+    });
+
+    Views::new(views.as_mut_slice()).draw(&mut display).unwrap();
+
+    Window::new("Dynamic Layout Example", &output_settings).show_static(&display);
+    Ok(())
+}


### PR DESCRIPTION
First cut of the Enum Macro.

Currently it works on named and unamed enum variants. Each field must implement View + Drawable. I included an example that use a random number generator (`tinyrng` to stick to the `no-std` depandancies) to pick what variant should be displayed to prove that any can be selected. 

One of the problems I am currently running into is that it does now work with LinearLayout. The problem is that LinearLayout does not implement Clone + Copy which causes the impl Transform to fail since the translate is given a `&self` and usally calls translate which accepts a `mut self`. Have to see if there is another way to implement it but it seems like I will need to add Clone + Copy to LinearLayout (which in turn means it has to be added to Views and Chain). Not sure if that is doable on Views since it holds a `&'a mut [T] `. Any feedback/suggestions is greatly appericated. Thanks.