### PR TITLE
Implement Clone for LinearLayout and Chains

### DIFF
--- a/src/layout/linear/mod.rs
+++ b/src/layout/linear/mod.rs
@@ -222,6 +222,20 @@ where
     }
 }
 
+impl<LD, VG> Clone for LinearLayout<LD, VG>
+where
+    LD: Orientation,
+    VG: ViewGroup + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            position: self.position,
+            direction: self.direction,
+            views: self.views.clone(),
+        }
+    }
+}
+
 impl<LD, VG> LinearLayout<LD, VG>
 where
     LD: Orientation,

--- a/src/object_chain.rs
+++ b/src/object_chain.rs
@@ -38,6 +38,19 @@ impl<V, C: ChainElement> Link<V, C> {
     }
 }
 
+impl<V, C> Clone for Link<V, C>
+where
+    V: Clone,
+    C: ChainElement + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            object: self.object.clone(),
+            parent: self.parent.clone(),
+        }
+    }
+}
+
 impl<V, VC> ChainElement for Link<V, VC>
 where
     VC: ChainElement,
@@ -70,6 +83,17 @@ impl<V> Chain<V> {
     #[inline]
     pub const fn new(object: V) -> Self {
         Self { object }
+    }
+}
+
+impl<V> Clone for Chain<V>
+where
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            object: self.object.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
Added Clone implementation for LinearLayout and the ViewGroup Chain. This will allow for the use of LinearLayouts that are backed by the Chain ViewGroup to be used with the ViewEnum macro. Also modified the ViewEnum macro to explicitly call Clone(). Previously we used structures that implemented Copy. Since cloning Chains is non-trivial we need to call clone explicitly.