### PR TITLE
Added missing clone() call

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -180,8 +180,9 @@ pub fn derive_viewgroup(input: TokenStream) -> TokenStream {
                                 }
                             };
 
-                            let translate_fields =
-                                field_idents.iter().map(|f| quote!(#f.clone().translate(by), ));
+                            let translate_fields = field_idents
+                                .iter()
+                                .map(|f| quote!(#f.clone().translate(by), ));
                             let enum_translate = quote! {
                                 Self::#variant_name(#(#field_idents),*) => {
                                     Self::#variant_name(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -181,7 +181,7 @@ pub fn derive_viewgroup(input: TokenStream) -> TokenStream {
                             };
 
                             let translate_fields =
-                                field_idents.iter().map(|f| quote!(#f.translate(by), ));
+                                field_idents.iter().map(|f| quote!(#f.clone().translate(by), ));
                             let enum_translate = quote! {
                                 Self::#variant_name(#(#field_idents),*) => {
                                     Self::#variant_name(


### PR DESCRIPTION
Forgot a clone() call in the translate() function for the unamed fields enum type.