### PR TITLE
Fix Distributed fill for one element

### DIFF
--- a/src/layout/linear/spacing.rs
+++ b/src/layout/linear/spacing.rs
@@ -138,6 +138,11 @@ impl ElementSpacing for DistributeFill {
     ) -> i32 {
         // bit of a mess, but calculate using i32 in case the views don't fit the space
         let empty_space = self.0 as i32 - total_size as i32;
+
+        if objects <= 1 {
+            return alignment.align_with_offset(view, reference, empty_space / 2);
+        }
+
         let base = empty_space / (objects - 1) as i32;
         let remainder = empty_space % (objects - 1) as i32;
 


### PR DESCRIPTION
This PR fixes crash on attempt to `DistributeFill` a layout with one element:
```rust
LinearLayout::horizontal(Chain::new(time))
        .with_spacing(DistributeFill(widget_size.width))
        .arrange();
```

Now the element is centered as expected.